### PR TITLE
upgrade mongo-java-driver 3.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,62 @@
+# See http://about.travis-ci.org/docs/user/build-configuration/
+language: scala
+scala:
+  - 2.12.1
+  - 2.11.8
+  - 2.10.5
+jdk:
+  - openjdk7
+  - openjdk8
+
+addons:
+  # Fix OpenJDK build. Issue: https://github.com/travis-ci/travis-ci/issues/5227
+  hostname: short-hostname
+
+# Branches to test
+branches:
+  only:
+    - master
+    - 3.6.x
+notifications:
+  email:
+    recipients:
+      - raulrodriguez782@gmail.com
+    on_success: change
+    on_failure: always
+
+matrix:
+  fast_finish: true
+  exclude:
+    - scala: 2.12.1
+      jdk: openjdk7
+
+env:
+  global:
+    - MONGO_REPO="http://repo.mongodb.com/apt/ubuntu"
+    - REPO_TYPE="xenial/mongodb-enterprise/3.6 multiverse"
+    - SOURCES_LOC="/etc/apt/sources.list.d/mongodb-enterprise.list"
+    - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
+    - MONGOD_PARAMS="--setParameter=enableTestCommands=1"
+    - MONGOD_OPTS="--dbpath ./data --fork --logpath mongod.log ${MONGOD_PARAMS}"
+    - TERM=dumb
+
+before_install:
+  # MongoDB Enterprise Edition 3.6
+  - sudo apt-get install libcurl3 libgssapi-krb5-2 libkrb5-dbg libldap-2.4-2 libpci3 libwrap0 libsasl2-2 libsensors4 snmp openssl
+  - sudo apt-get remove mongodb
+  - wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.16.tgz
+  - tar -zxvf mongodb-linux-x86_64-ubuntu1604-3.6.16.tgz
+  - sudo mkdir -p data
+  # Update all the repositories
+  - sudo apt-get update -qq
+
+install:
+  # Install MongoDB Enterprise
+  - sudo cp mongodb-linux-x86_64-ubuntu1604-3.6.16/bin/* /usr/bin/
+
+before_script:
+  - sudo mongod ${MONGOD_OPTS}
+
+script:
+  - ./sbt ++$TRAVIS_SCALA_VERSION test
+

--- a/casbah-core/src/test/scala/MongoOpLogSpec.scala
+++ b/casbah-core/src/test/scala/MongoOpLogSpec.scala
@@ -40,7 +40,8 @@ class MongoOpLogSpec extends CasbahDBTestSpecification with Mockito {
         "v" -> 2,
         "op" -> "n",
         "ns" -> "",
-        "o" -> Map.empty)
+        "o" -> Map.empty
+      )
 
       cursor.next() returns x
 
@@ -74,7 +75,8 @@ class MongoOpLogSpec extends CasbahDBTestSpecification with Mockito {
       val oplog =
         new MongoOpLog(
           mongoClient = mongoClient,
-          namespace = Some("%s.%s".format(database.name, collection.name)))
+          namespace = Some("%s.%s".format(database.name, collection.name))
+        )
 
       var latest = false
       while (!latest && oplog.hasNext) {

--- a/project/CasbahBuild.scala
+++ b/project/CasbahBuild.scala
@@ -40,7 +40,7 @@ object CasbahBuild extends Build {
    */
   lazy val scalacOptionsSettings = Seq(scalacOptions ++= (scalaBinaryVersion.value match {
     case "2.10" => Seq("-unchecked", "-feature", "-Xlint")
-    case _ => Seq("-unchecked", "-feature", "-Xlint:-missing-interpolator")
+    case _ => Seq("-unchecked", "-deprecation", "-feature", "-Xlint:-missing-interpolator")
   }))
 
   /*

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@
 import sbt._
 
 object Dependencies {
-  val mongoJavaDriver  = "org.mongodb" % "mongo-java-driver" % "3.2.2"
+  val mongoJavaDriver  = "org.mongodb" % "mongo-java-driver" % "3.6.4"
   val slf4j            = "org.slf4j" % "slf4j-api" % "1.6.0"
   val junit            = "junit" % "junit" % "4.10" % "test"
   val slf4jJCL         = "org.slf4j" % "slf4j-jcl" % "1.6.0" % "test"


### PR DESCRIPTION
- Add travis.yml back - support oraclejdk8 and mongo 3.6.16 enterprise

- Upgrade mongo-java-driver 3.6.4